### PR TITLE
Add ability to prevent html escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.0 - 2021-05-06
+### Added
+- Ability to disable all HTML escaping by setting the `should_escape_html` flag to `false` when instantiating
+  `Exclaim::Ui`, e.g. `Exclaim::Ui.new(implementation_map: my_implementation_map, should_escape_html: false)`
+
 ## 0.0.0 - 2021-02-12
 ### Added
 - Initial version

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     + [Shorthand Properties and Configuration Defaults](#shorthand-properties-and-configuration-defaults)
     + [Security Considerations](#security-considerations)
       - [Script Injection](#script-injection)
+      - [Disable HTML escaping](#disable-html-escaping)
       - [Unintended Tracking/HTTP Requests](#unintended-trackinghttp-requests)
   * [Querying the Parsed UI](#querying-the-parsed-ui)
   * [Utilities](#utilities)
@@ -632,6 +633,19 @@ If you do need to embed raw HTML, and you are _certain_ you can trust the input,
 your implementation can call `CGI.unescape_html` or `CGI.unescape_element`.
 See [CGI::Util](https://ruby-doc.org/stdlib-3.0.0/libdoc/cgi/rdoc/CGI/Util.html)
 in the Ruby standard library for details.
+
+##### Disable HTML escaping
+
+You can disable HTML escaping altogether by setting the `should_escape_html` flag to `false` when instantiating
+`Exclaim::Ui`. You generally should only do this when the output will not be rendered directly to HTML as this could
+potentially allow script injection and other hazards of unescaped rendering of untrusted user input. If you use this
+flag and the output is ultimately destined for a browser, make sure something downstream between `Exclaim::Ui#render`
+and the browser will escape characters that have special meaning in HTML: `<` `>` `&` `"` `'`
+
+```
+exclaim_ui = Exclaim::Ui.new(implementation_map: my_implementation_map, should_escape_html: false)
+exclaim_ui.render(env: my_environment) # HTML characters will not be escaped
+```
 
 ##### Unintended Tracking/HTTP Requests
 

--- a/lib/exclaim/renderer.rb
+++ b/lib/exclaim/renderer.rb
@@ -2,8 +2,9 @@
 
 module Exclaim
   class Renderer
-    def initialize(parsed_ui)
+    def initialize(parsed_ui, should_escape_html = true)
       @parsed_ui = parsed_ui
+      @should_escape_html = should_escape_html
     end
 
     def call(env: {})
@@ -25,7 +26,7 @@ module Exclaim
     end
 
     def resolve_component_config(component, env)
-      resolve(component.config, env).transform_values! { |value| escape_html!(value) }
+      resolve(component.config, env).transform_values! { |value| @should_escape_html ? escape_html!(value) : value }
     end
 
     def escape_html!(value)

--- a/lib/exclaim/ui.rb
+++ b/lib/exclaim/ui.rb
@@ -4,8 +4,9 @@ module Exclaim
   class Ui
     attr_reader :implementation_map, :parsed_ui, :renderer
 
-    def initialize(implementation_map: Exclaim::Implementations.example_implementation_map)
+    def initialize(implementation_map: Exclaim::Implementations.example_implementation_map, should_escape_html: true)
       @implementation_map = Exclaim::ImplementationMap.parse!(implementation_map)
+      @should_escape_html = should_escape_html
     rescue Exclaim::Error
       raise
     rescue StandardError => e
@@ -66,7 +67,7 @@ module Exclaim
 
     def parsed_ui=(value)
       @parsed_ui = value
-      @renderer = Exclaim::Renderer.new(@parsed_ui)
+      @renderer = Exclaim::Renderer.new(@parsed_ui, @should_escape_html)
     end
 
     def bind_paths(config_value, accumulator)

--- a/lib/exclaim/version.rb
+++ b/lib/exclaim/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Exclaim
-  VERSION = '0.0.0'
+  VERSION = '0.1.0'
 end

--- a/spec/rendering/html_spec.rb
+++ b/spec/rendering/html_spec.rb
@@ -43,6 +43,26 @@ describe "rendering HTML configuration values" do
     end
   end
 
+  describe "it does not escape HTML config values when told not to" do
+    let(:exclaim_ui) { Exclaim::Ui.new(implementation_map: implementation_map, should_escape_html: false) }
+    let(:component_implementation) do
+      ->(config, _env) { "#{config['config_value']} #{config['bind_value']}" }
+    end
+
+    it "does not replace <, >, &, \", and ' in string config values" do
+      parsed_component.config = {
+        'config_value' => '<script>alert("Hello");</script>',
+        'bind_value' => bind
+      }
+      env = { 'env_value' => "<img src='http://test.com/tracking-pixel.png?source=A&type=Z'>" }
+
+      result = exclaim_ui.render(env: env)
+      expect(result).to eq(
+        '<script>alert("Hello");</script> <img src=\'http://test.com/tracking-pixel.png?source=A&type=Z\'>'
+      )
+    end
+  end
+
   context "when rendering helpers" do
     let(:component_implementation) do
       ->(config, _env) { config['config_value'] }


### PR DESCRIPTION
This adds the ability to prevent HTML escaping when rendering via a boolean kwarg (`should_escape_html`) that defaults to `true`.